### PR TITLE
Add none attestation format per section 8.7

### DIFF
--- a/attestation/attestion.go
+++ b/attestation/attestion.go
@@ -4,5 +4,6 @@ package attestation
 import (
 	_ "github.com/koesie10/webauthn/attestation/androidsafetynet"
 	_ "github.com/koesie10/webauthn/attestation/fido"
+	_ "github.com/koesie10/webauthn/attestation/none"
 	_ "github.com/koesie10/webauthn/attestation/packed"
 )

--- a/attestation/none/none.go
+++ b/attestation/none/none.go
@@ -1,0 +1,16 @@
+// none implements the None (WebAuthn spec section 8.7) attestation statement format
+package none
+
+import "github.com/koesie10/webauthn/protocol"
+
+func init() {
+	protocol.RegisterFormat("none", verifyNoneFormat)
+}
+
+func verifyNoneFormat(a protocol.Attestation, clientDataHash []byte) error {
+	if len(a.AttStmt) > 0 {
+		return protocol.ErrInvalidAttestation.WithDebug("invalid attStmt for 'none' attestation")
+	}
+
+	return nil
+}


### PR DESCRIPTION
This is useful if you set:

  Attestation = AttestationConveyancePreferenceNone

which is the recommended setting for public websites by Adam Langley (agl):
https://www.imperialviolet.org/2019/01/01/zkattestation.html